### PR TITLE
Fix Issue #30 - missing include_client_id

### DIFF
--- a/example/main.py
+++ b/example/main.py
@@ -20,6 +20,7 @@ if __name__ == "__main__":
         token_url=token_url,
         client_id=CLIENT_ID,
         client_secret=CLIENT_SECRET,
+        include_client_id=True,
         audience="https://api2.arduino.cc/iot",
     )
 


### PR DESCRIPTION
Adding fix to the example code that cannot generate the access token.
Related link: https://forum.arduino.cc/index.php?topic=661378.0
Reference: https://github.com/requests/requests-oauthlib/issues/360