### PR TITLE
Updating deprecated GH version to stable release

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,7 +27,7 @@ jobs:
           python setup.py bdist_wheel
 
       - name: Upload packate to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.pypi_token }}


### PR DESCRIPTION
Pin python release to stable release version (as per GH documentation)